### PR TITLE
Fix LuhnAlgorithm reference

### DIFF
--- a/src/ValidatorService/Helpers/LuhnAlgorithm.cs
+++ b/src/ValidatorService/Helpers/LuhnAlgorithm.cs
@@ -2,6 +2,7 @@ namespace ValidatorService.Helpers;
 
 /// <summary>
 /// Provides utility methods for validating credit card numbers using the **Luhn Algorithm**.
+/// Inspired by: <see href="https://github.com/KnowledgeForwardSolutions/Medium/blob/main/A002LuhnAlgorithm/CheckDigits/LuhnAlgorithm.cs">KnowledgeForwardSolutions</see>.
 /// </summary>
 public static class LuhnAlgorithm
 {


### PR DESCRIPTION
Adding a reference provides proper attribution, helps others understand where the inspiration came from, and maintains transparency.