### PR TITLE
Simplify API response structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ Swagger is available at:
   ```json
   {
     "status": 200,
-    "message": "Valid card number."
+    "data": {
+      "isValid": true
+    }
   }
   ```
 
@@ -143,7 +145,6 @@ Swagger is available at:
   ```json
   {
     "status": 400,
-    "message": "The 'cardNumber' field is required.",
     "error": {
       "code": "missing_field",
       "details": "Please provide a valid card number."
@@ -151,12 +152,14 @@ Swagger is available at:
   }
   ```
 
-- **422 Unprocessable Entity (Invalid Card Number Length)**
+- **200 OK (Invalid Card Number Length)**
 
   ```json
   {
-    "status": 422,
-    "message": "Invalid card number length.",
+    "status": 200,
+    "data": {
+      "isValid": false
+    },
     "error": {
       "code": "invalid_length",
       "details": "Card number length must be between 13 and 19 digits."
@@ -164,12 +167,14 @@ Swagger is available at:
   }
   ```
 
-- **422 Unprocessable Entity (Invalid Card Number Format)**
+- **200 OK (Invalid Card Number Format)**
 
   ```json
   {
-    "status": 422,
-    "message": "Invalid card number format.",
+    "status": 200,
+    "data": {
+      "isValid": false
+    },
     "error": {
       "code": "invalid_format",
       "details": "Card number must contain only numeric digits (0-9)."
@@ -177,12 +182,14 @@ Swagger is available at:
   }
   ```
 
-- **422 Unprocessable Entity (Invalid Card Number)**
+- **200 OK (Invalid Card Number)**
 
   ```json
   {
-    "status": 422,
-    "message": "Invalid card number.",
+    "status": 200,
+    "data": {
+      "isValid": false
+    },
     "error": {
       "code": "invalid_number",
       "details": "The card number does not pass the Luhn algorithm validation, please try again."
@@ -195,7 +202,6 @@ Swagger is available at:
   ```json
   {
     "status": 500,
-    "message": "An error occurred while processing your request.",
     "error": {
       "code": "internal_error",
       "details": "An unexpected error occurred. Please try again later."

--- a/src/ValidatorService/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/ValidatorService/Middleware/ExceptionHandlingMiddleware.cs
@@ -32,7 +32,6 @@ public class ExceptionHandlingMiddleware
     {
         var response = new ApiResponse<object>(
             StatusCodes.Status500InternalServerError,
-            "An error occurred while processing your request.",
             error: new ErrorDetails("internal_error", "An unexpected error occurred. Please try again later.")
         );
 

--- a/src/ValidatorService/Models/ApiResponse.cs
+++ b/src/ValidatorService/Models/ApiResponse.cs
@@ -5,20 +5,14 @@ namespace ValidatorService.Models;
 /// </summary>
 /// <typeparam name="T">Type of the data payload.</typeparam>
 /// <param name="status">HTTP status code of the response.</param>
-/// <param name="message">Descriptive message about the response.</param>
 /// <param name="data">The response data (optional, null if not applicable).</param>
 /// <param name="error">Details of an error if applicable (null if no error).</param>
-public class ApiResponse<T>(int status, string message, T? data = default, ErrorDetails? error = null)
+public class ApiResponse<T>(int status, T? data = default, ErrorDetails? error = null)
 {
     /// <summary>
-    /// HTTP status code of the response (e.g., 200, 400, 422).
+    /// HTTP status code of the response (e.g., 200, 400).
     /// </summary>
     public int Status { get; set; } = status;
-
-    /// <summary>
-    /// A descriptive message explaining the response status.
-    /// </summary>
-    public string Message { get; set; } = message;
 
     /// <summary>
     /// The actual data returned in the response, if applicable.

--- a/src/ValidatorService/Models/ValidatorResponse.cs
+++ b/src/ValidatorService/Models/ValidatorResponse.cs
@@ -1,0 +1,12 @@
+namespace ValidatorService.Models;
+
+/// <summary>
+/// Represents a response to validate a credit card number.
+/// </summary>
+public class ValidatorResponse
+{
+    /// <summary>
+    /// Indicates whether the provided credit card number is valid.
+    /// </summary>
+    public bool IsValid { get; set; }
+}

--- a/tests/ValidatorService.IntegrationTests/LuhnEndpointTests.cs
+++ b/tests/ValidatorService.IntegrationTests/LuhnEndpointTests.cs
@@ -38,15 +38,17 @@ public class LuhnEndpointTests : IClassFixture<WebApplicationFactory<Program>>
         var response = await _client.PostAsync(Path, content);
 
         // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var responseBody = await response.Content.ReadFromJsonAsync<ApiResponse<ValidatorResponse>>();
+        Assert.NotNull(responseBody);
         if (expectedValid)
         {
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Null(responseBody.Error);
+            Assert.NotNull(responseBody.Data);
+            Assert.True(responseBody.Data.IsValid);
         }
         else
         {
-            Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
-            var responseBody = await response.Content.ReadFromJsonAsync<ApiResponse<object>>();
-            Assert.NotNull(responseBody);
             Assert.NotNull(responseBody.Error);
             if (number.Length >= 13 && number.Length <= 19)
             {
@@ -56,6 +58,8 @@ public class LuhnEndpointTests : IClassFixture<WebApplicationFactory<Program>>
             {
                 Assert.Equal("invalid_length", responseBody.Error.Code);
             }
+            Assert.NotNull(responseBody.Data);
+            Assert.False(responseBody.Data.IsValid);
         }
     }
 
@@ -77,8 +81,8 @@ public class LuhnEndpointTests : IClassFixture<WebApplicationFactory<Program>>
         var response = await _client.PostAsync(Path, content);
 
         // Assert
-        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
-        var responseBody = await response.Content.ReadFromJsonAsync<ApiResponse<object>>();
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var responseBody = await response.Content.ReadFromJsonAsync<ApiResponse<ValidatorResponse>>();
         Assert.NotNull(responseBody);
         Assert.NotNull(responseBody.Error);
         Assert.Equal(expectedErrorCode, responseBody.Error.Code);
@@ -95,7 +99,7 @@ public class LuhnEndpointTests : IClassFixture<WebApplicationFactory<Program>>
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var responseBody = await response.Content.ReadFromJsonAsync<ApiResponse<object>>();
+        var responseBody = await response.Content.ReadFromJsonAsync<ApiResponse<ValidatorResponse>>();
         Assert.NotNull(responseBody);
         Assert.NotNull(responseBody.Error);
         Assert.Equal("missing_field", responseBody.Error.Code);
@@ -109,7 +113,7 @@ public class LuhnEndpointTests : IClassFixture<WebApplicationFactory<Program>>
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var responseBody = await response.Content.ReadFromJsonAsync<ApiResponse<object>>();
+        var responseBody = await response.Content.ReadFromJsonAsync<ApiResponse<ValidatorResponse>>();
         Assert.NotNull(responseBody);
         Assert.NotNull(responseBody.Error);
         Assert.Equal("missing_body", responseBody.Error.Code);


### PR DESCRIPTION
Simplify API response structure

Commit Description:

- Removed 422 Unprocessable Entity and unified all validation responses under 200 OK.
- Added isValid field to data object in the response.
- Simplified error handling:
- If the request is valid, API returns { "isValid": true/false }.
- If the request is malformed, API responds with 400 Bad Request and includes an error object.
- Updated ValidatorResponse model to ensure consistency.